### PR TITLE
allow psutil to be higher

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - fake-factory
     - gitpython
     - fuzzywuzzy
-    - psutil >=1.2.1,<=2.2.1
+    - psutil >=1.2.1
     - setproctitle
     - gnureadline ==6.3.3  # [osx]
 


### PR DESCRIPTION
removing the upper bound on psutil should (might?) fix some problems psiturk anaconda users have been having.
